### PR TITLE
Netcdf CF compliance + a bit more

### DIFF
--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -19,34 +19,34 @@ def init_output():
     lat = out.createDimension("lat", global_const.NK)
 
     # create variables
-    longitudes = out.createVariable("lon", np.float, "lon", fill_value=False)
-    latitudes = out.createVariable("lat", np.float, "lat", fill_value=False)
-    time = out.createVariable("time", np.float, "time", fill_value=False)
+    longitudes = out.createVariable("lon", "d", "lon", fill_value=False)
+    latitudes = out.createVariable("lat", "d", "lat", fill_value=False)
+    time = out.createVariable("time", "d", "time", fill_value=False)
 
-    SE = out.createVariable("SE", np.float, ("lat", "lon"), fill_value=np.nan)
+    SE = out.createVariable("SE", "f", ("lat", "lon"), fill_value=np.nan)
 
     PSG = out.createVariable(
-        "PSG", np.float, ("time", "lat", "lon"), fill_value=np.nan
+        "PSG", "f", ("time", "lat", "lon"), fill_value=np.nan
     )  # NetCDF has (level, time, lat, lon) as standard
 
     T = out.createVariable(
-        "T", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "T", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     U = out.createVariable(
-        "U", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "U", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     V = out.createVariable(
-        "V", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "V", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     #    W = out.createVariable(
-    #        "W", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "W", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
     #    GP = out.createVariable(
-    #        "GP", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "GP", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
     # set axis attriute

--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -19,34 +19,34 @@ def init_output():
     lat = out.createDimension("lat", global_const.NK)
 
     # create variables
-    longitudes = out.createVariable("lon", np.float, "lon", fill_value=np.nan)
-    latitudes = out.createVariable("lat", np.float, "lat", fill_value=np.nan)
-    time = out.createVariable("time", np.float, "time", fill_value=np.nan)
+    longitudes = out.createVariable("lon", np.float, "lon")
+    latitudes = out.createVariable("lat", np.float, "lat")
+    time = out.createVariable("time", np.float, "time")
 
-    SE = out.createVariable("SE", np.float, ("lat", "lon"), fill_value=np.nan)
+    SE = out.createVariable("SE", np.float, ("lat", "lon"))
 
     PSG = out.createVariable(
-        "PSG", np.float, ("time", "lat", "lon"), fill_value=np.nan
+        "PSG", np.float, ("time", "lat", "lon")
     )  # NetCDF has (level, time, lat, lon) as standard
 
     T = out.createVariable(
-        "T", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "T", np.float, ("time", "level", "lat", "lon")
     )
 
     U = out.createVariable(
-        "U", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "U", np.float, ("time", "level", "lat", "lon")
     )
 
     V = out.createVariable(
-        "V", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "V", np.float, ("time", "level", "lat", "lon")
     )
 
     #    W = out.createVariable(
-    #        "W", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "W", np.float, ("time", "level", "lat", "lon")
     #    )
 
     #    GP = out.createVariable(
-    #        "GP", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "GP", np.float, ("time", "level", "lat", "lon")
     #    )
 
     # assign units

--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -19,34 +19,34 @@ def init_output():
     lat = out.createDimension("lat", global_const.NK)
 
     # create variables
-    longitudes = out.createVariable("lon", np.float, "lon", fill_value=np.nan)
-    latitudes = out.createVariable("lat", np.float, "lat", fill_value=np.nan)
-    time = out.createVariable("time", np.float, "time", fill_value=np.nan)
+    longitudes = out.createVariable("lon", 'd', "lon", fill_value=np.nan)
+    latitudes = out.createVariable("lat", 'd', "lat", fill_value=np.nan)
+    time = out.createVariable("time", 'd', "time", fill_value=np.nan)
 
-    SE = out.createVariable("SE", np.float, ("lat", "lon"), fill_value=np.nan)
+    SE = out.createVariable("SE", 'f', ("lat", "lon"), fill_value=np.nan)
 
     PSG = out.createVariable(
-        "PSG", np.float, ("time", "lat", "lon"), fill_value=np.nan
+        "PSG", 'f', ("time", "lat", "lon"), fill_value=np.nan
     )  # NetCDF has (level, time, lat, lon) as standard
 
     T = out.createVariable(
-        "T", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "T", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     U = out.createVariable(
-        "U", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "U", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     V = out.createVariable(
-        "V", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+        "V", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     )
 
     #    W = out.createVariable(
-    #        "W", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "W", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
     #    GP = out.createVariable(
-    #        "GP", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "GP", 'f', ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
     # assign units

--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -19,9 +19,9 @@ def init_output():
     lat = out.createDimension("lat", global_const.NK)
 
     # create variables
-    longitudes = out.createVariable("lon", np.float, "lon", fill_value=np.nan)
-    latitudes = out.createVariable("lat", np.float, "lat", fill_value=np.nan)
-    time = out.createVariable("time", np.float, "time", fill_value=np.nan)
+    longitudes = out.createVariable("lon", np.float, "lon", fill_value=False)
+    latitudes = out.createVariable("lat", np.float, "lat", fill_value=False)
+    time = out.createVariable("time", np.float, "time", fill_value=False)
 
     SE = out.createVariable("SE", np.float, ("lat", "lon"), fill_value=np.nan)
 
@@ -49,6 +49,11 @@ def init_output():
     #        "GP", np.float, ("time", "level", "lat", "lon"), fill_value=np.nan
     #    )
 
+    # set axis attriute
+    longitudes.axis = "X"
+    latitudes.axis = "Y"
+    time.axis = "T"  # Coordinated Universal Time
+
     # assign units
     longitudes.units = "degrees_east"
     latitudes.units = "degrees_north"
@@ -62,7 +67,11 @@ def init_output():
     #    W.units = "1/s"
     #    GP.units = "J/kg"
 
-    # assign names
+    # assign long names
+    longitudes.long_name = 'longitude'
+    latitudes.long_name = 'latitude'
+    time.long_name = 'time'
+
     SE.long_name = "Surface Elevation"
     PSG.long_name = "Sea Level Pressure"
     T.long_name = "Temperature"
@@ -70,6 +79,19 @@ def init_output():
     V.long_name = "Meridional Wind"
     #    W.long_name = "Vertical Speed"
     #    GP.long_name = "Geopotential"
+
+    # assign standard names
+    longitudes.standard_name = 'longitude'
+    latitudes.standard_name = 'latitude'
+    time.standard_name = 'time'
+
+    SE.standard_name = None
+    PSG.standard_name = "air_pressure_at_mean_sea_level"
+    T.standard_name = "air_temperature"
+    U.standard_name = "eastward_wind"
+    V.standard_name = "northward_wind"
+    #    W.standard_name = None
+    #    GP.standard_name = "geopotential"
 
     # fill lon/lat
     longitudes[:] = global_array.flam_deg[1 : global_const.NJ + 1]
@@ -79,6 +101,30 @@ def init_output():
         datetime.strptime(global_str.start_time, "%d.%m.%Y %H:%M:%S")
         - datetime.strptime("08.10.1992 15:15:42.5", "%d.%m.%Y %H:%M:%S.%f")
     ).total_seconds()
+
+    new_glob_attrs = {
+        'title': "GLOBAGRIM simulation",
+        'experiment': None,
+        'Conventions': "CF-1.7",
+        'project': None,
+        'source': "globagrim v0.1",
+        'license': None,
+        'institution': "DKRZ, Germany",
+        'contact': "Marco Kulueke, kulueke@dkrz.de",
+        'frequency': None,
+        # 'proj_string': "+proj: lcc +lat_1: 53.0 +lat_2: 54.0 +lat_0: 53.55 +lon_0: 10.0 +ellps: WGS84 +datum: WGS84",
+        'history': "created by globagrim v0.1",
+    }
+    # `history` could contain a set of parameters provided to the `model()` call?
+    # 
+    # `source`: maybe use information from the `setup.py` for this purpose
+    # 
+    # These are more attributes than the CF Conventions suggest. Some are
+    # taken from the ACDD conventions (https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3).
+    # One could consider adding `geospatial_lat_resolution` and
+    # `geospatial_lon_resolution` if the lat and lon steps are fixed in space.
+
+    out.setncatts(new_glob_attrs)
 
 
 def fill_output():

--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -1,4 +1,5 @@
 import numpy as np
+import netCDF4
 from netCDF4 import Dataset
 from datetime import datetime
 import os
@@ -23,30 +24,30 @@ def init_output():
     latitudes = out.createVariable("lat", "d", "lat", fill_value=False)
     time = out.createVariable("time", "d", "time", fill_value=False)
 
-    SE = out.createVariable("SE", "f", ("lat", "lon"), fill_value=np.nan)
+    SE = out.createVariable("SE", "f", ("lat", "lon"), fill_value=netCDF4.default_fillvals['f4'])
 
     PSG = out.createVariable(
-        "PSG", "f", ("time", "lat", "lon"), fill_value=np.nan
+        "PSG", "f", ("time", "lat", "lon"), fill_value=netCDF4.default_fillvals['f4']
     )  # NetCDF has (level, time, lat, lon) as standard
 
     T = out.createVariable(
-        "T", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
+        "T", "f", ("time", "level", "lat", "lon"), fill_value=netCDF4.default_fillvals['f4']
     )
 
     U = out.createVariable(
-        "U", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
+        "U", "f", ("time", "level", "lat", "lon"), fill_value=netCDF4.default_fillvals['f4']
     )
 
     V = out.createVariable(
-        "V", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
+        "V", "f", ("time", "level", "lat", "lon"), fill_value=netCDF4.default_fillvals['f4']
     )
 
     #    W = out.createVariable(
-    #        "W", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "W", "f", ("time", "level", "lat", "lon"), fill_value=netCDF4.default_fillvals['f4']
     #    )
 
     #    GP = out.createVariable(
-    #        "GP", "f", ("time", "level", "lat", "lon"), fill_value=np.nan
+    #        "GP", "f", ("time", "level", "lat", "lon"), fill_value=netCDF4.default_fillvals['f4']
     #    )
 
     # set axis attriute

--- a/globagrim/output.py
+++ b/globagrim/output.py
@@ -53,6 +53,7 @@ def init_output():
     longitudes.axis = "X"
     latitudes.axis = "Y"
     time.axis = "T"  # Coordinated Universal Time
+    time.calendar = "gregorian"
 
     # assign units
     longitudes.units = "degrees_east"
@@ -85,7 +86,7 @@ def init_output():
     latitudes.standard_name = 'latitude'
     time.standard_name = 'time'
 
-    SE.standard_name = None
+    # SE.standard_name = None
     PSG.standard_name = "air_pressure_at_mean_sea_level"
     T.standard_name = "air_temperature"
     U.standard_name = "eastward_wind"
@@ -104,14 +105,14 @@ def init_output():
 
     new_glob_attrs = {
         'title': "GLOBAGRIM simulation",
-        'experiment': None,
+        # 'experiment': None,
         'Conventions': "CF-1.7",
-        'project': None,
+        # 'project': None,
         'source': "globagrim v0.1",
-        'license': None,
+        # 'license': None,
         'institution': "DKRZ, Germany",
         'contact': "Marco Kulueke, kulueke@dkrz.de",
-        'frequency': None,
+        # 'frequency': None,
         # 'proj_string': "+proj: lcc +lat_1: 53.0 +lat_2: 54.0 +lat_0: 53.55 +lon_0: 10.0 +ellps: WGS84 +datum: WGS84",
         'history': "created by globagrim v0.1",
     }


### PR DESCRIPTION
CF Compliance:

* coordinate variables must not have _FillValue
* added `standard_name` attribute applicable
* added `axis` attribute to spatio-temporal axes
* added global attribute `Conventions`
* added `history` and `institution` global attributes
* added some global attributes from ACDD conventions
* added `calendar` attribute for `time`

Fill Values:

* `np.nan` is not a good choice for a manually defined fill value.
* Commonly, very high or very low numbers are choosen.
* I added netCDF4.defaults['f4'] as fill value for the data variables (32bit floats; see below).
* The coordinate variables are not allowed to have fill values according to CF Conventions. Set `fill_value=False` for these.

common choice of data types (modified accordingly):

* coordinates variables are of type `double` (higher precision; higher
   numbers => `time` is seconds since => float often to small)
* data variables are of type `float`
* possible input types for the netCDF python4 API are given here: https://unidata.github.io/netcdf4-python/#Dataset.createVariable